### PR TITLE
Support configuring [nss] block

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,8 +17,10 @@
 # limitations under the License.
 #
 
-default['sssd_ldap']['filter_users'] = %w(root named avahi haldaemon dbus radiusd news nscd)
-default['sssd_ldap']['filter_groups'] = []
+default['sssd_ldap']['nss_conf']['filter_users'] = 'root,named,avahi,haldaemon,dbus,radiusd,news,nscd'
+default['sssd_ldap']['nss_conf']['filter_groups'] = nil
+default['sssd_ldap']['nss_conf']['override_homedir'] = nil
+default['sssd_ldap']['nss_conf']['override_shell'] = nil
 default['sssd_ldap']['sssd_conf']['id_provider'] = 'ldap'
 default['sssd_ldap']['sssd_conf']['auth_provider'] = 'ldap'
 default['sssd_ldap']['sssd_conf']['chpass_provider'] = 'ldap'
@@ -57,6 +59,3 @@ default['sssd_ldap']['sssd_conf']['max_id'] = '0'
 default['sssd_ldap']['ldap_sudo'] = false
 default['sssd_ldap']['ldap_autofs'] = false
 default['sssd_ldap']['ldap_ssh'] = false
-
-default['sssd_ldap']['sssd_service_conf']['override_homedir'] = nil
-default['sssd_ldap']['sssd_service_conf']['override_shell'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,9 +19,6 @@
 
 # Attributes that relate to [nss] section
 default['sssd_ldap']['nss_service_conf']['filter_users'] = 'root,named,avahi,haldaemon,dbus,radiusd,news,nscd'
-default['sssd_ldap']['nss_service_conf']['filter_groups'] = nil
-default['sssd_ldap']['nss_service_conf']['override_homedir'] = nil
-default['sssd_ldap']['nss_service_conf']['override_shell'] = nil
 
 default['sssd_ldap']['sssd_conf']['id_provider'] = 'ldap'
 default['sssd_ldap']['sssd_conf']['auth_provider'] = 'ldap'
@@ -36,8 +33,6 @@ default['sssd_ldap']['sssd_conf']['ldap_search_base'] = 'dc=yourcompany,dc=com'
 default['sssd_ldap']['sssd_conf']['ldap_user_search_base'] = 'ou=People,dc=yourcompany,dc=com'
 default['sssd_ldap']['sssd_conf']['ldap_user_object_class'] = 'posixAccount'
 default['sssd_ldap']['sssd_conf']['ldap_user_name'] = 'uid'
-default['sssd_ldap']['sssd_conf']['override_homedir'] = nil
-default['sssd_ldap']['sssd_conf']['shell_fallback'] = '/bin/bash'
 
 default['sssd_ldap']['sssd_conf']['ldap_group_search_base'] = 'ou=Groups,dc=yourcompany,dc=com'
 default['sssd_ldap']['sssd_conf']['ldap_group_object_class'] = 'posixGroup'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -57,3 +57,6 @@ default['sssd_ldap']['sssd_conf']['max_id'] = '0'
 default['sssd_ldap']['ldap_sudo'] = false
 default['sssd_ldap']['ldap_autofs'] = false
 default['sssd_ldap']['ldap_ssh'] = false
+
+default['sssd_ldap']['sssd_service_conf']['override_homedir'] = nil
+default['sssd_ldap']['sssd_service_conf']['override_shell'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,6 +21,9 @@ default['sssd_ldap']['nss_conf']['filter_users'] = 'root,named,avahi,haldaemon,d
 default['sssd_ldap']['nss_conf']['filter_groups'] = nil
 default['sssd_ldap']['nss_conf']['override_homedir'] = nil
 default['sssd_ldap']['nss_conf']['override_shell'] = nil
+
+default['sssd_ldap']['sssd_service_conf'] = nil
+
 default['sssd_ldap']['sssd_conf']['id_provider'] = 'ldap'
 default['sssd_ldap']['sssd_conf']['auth_provider'] = 'ldap'
 default['sssd_ldap']['sssd_conf']['chpass_provider'] = 'ldap'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,12 +17,11 @@
 # limitations under the License.
 #
 
+# Attributes that relate to [nss] section
 default['sssd_ldap']['nss_conf']['filter_users'] = 'root,named,avahi,haldaemon,dbus,radiusd,news,nscd'
 default['sssd_ldap']['nss_conf']['filter_groups'] = nil
 default['sssd_ldap']['nss_conf']['override_homedir'] = nil
 default['sssd_ldap']['nss_conf']['override_shell'] = nil
-
-default['sssd_ldap']['sssd_service_conf'] = {}
 
 default['sssd_ldap']['sssd_conf']['id_provider'] = 'ldap'
 default['sssd_ldap']['sssd_conf']['auth_provider'] = 'ldap'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,7 +22,7 @@ default['sssd_ldap']['nss_conf']['filter_groups'] = nil
 default['sssd_ldap']['nss_conf']['override_homedir'] = nil
 default['sssd_ldap']['nss_conf']['override_shell'] = nil
 
-default['sssd_ldap']['sssd_service_conf'] = nil
+default['sssd_ldap']['sssd_service_conf'] = {}
 
 default['sssd_ldap']['sssd_conf']['id_provider'] = 'ldap'
 default['sssd_ldap']['sssd_conf']['auth_provider'] = 'ldap'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,10 +18,10 @@
 #
 
 # Attributes that relate to [nss] section
-default['sssd_ldap']['nss_conf']['filter_users'] = 'root,named,avahi,haldaemon,dbus,radiusd,news,nscd'
-default['sssd_ldap']['nss_conf']['filter_groups'] = nil
-default['sssd_ldap']['nss_conf']['override_homedir'] = nil
-default['sssd_ldap']['nss_conf']['override_shell'] = nil
+default['sssd_ldap']['nss_service_conf']['filter_users'] = 'root,named,avahi,haldaemon,dbus,radiusd,news,nscd'
+default['sssd_ldap']['nss_service_conf']['filter_groups'] = nil
+default['sssd_ldap']['nss_service_conf']['override_homedir'] = nil
+default['sssd_ldap']['nss_service_conf']['override_shell'] = nil
 
 default['sssd_ldap']['sssd_conf']['id_provider'] = 'ldap'
 default['sssd_ldap']['sssd_conf']['auth_provider'] = 'ldap'

--- a/templates/default/sssd.conf.erb
+++ b/templates/default/sssd.conf.erb
@@ -8,7 +8,7 @@ domains = LDAP
 
 [nss]
 filter_users = <%= node['sssd_ldap']['filter_users'].join(',') %>
-filter_groups = <% if not node['sssd_ldap']['filter_groups'].empty? %><%= node['sssd_ldap']['filter_groups'].join(',') %><% end %>
+filter_groups = <% if not node['sssd_ldap']['filter_groups'].nil? %><%= node['sssd_ldap']['filter_groups'].join(',') %><% end %>
 
 [pam]
 

--- a/templates/default/sssd.conf.erb
+++ b/templates/default/sssd.conf.erb
@@ -2,9 +2,6 @@
 config_file_version = 2
 services = nss, pam<% if node['sssd_ldap']['ldap_autofs'] %>, autofs<% end %><% if node['sssd_ldap']['ldap_ssh'] %>, ssh<% end %><% if node['sssd_ldap']['ldap_sudo'] && !(node['platform_family'] == 'rhel' && node['platform_version'].to_i < 6)%>, sudo<% end %>
 domains = LDAP
-<% node['sssd_ldap']['sssd_service_conf'].each do |key, value| %>
-<% if not value.nil? %><%= key %> = <%= value %><% end %>
-<% end %>
 
 [nss]
 <% node['sssd_ldap']['nss_service_conf'].each do |key, value| %>

--- a/templates/default/sssd.conf.erb
+++ b/templates/default/sssd.conf.erb
@@ -2,10 +2,13 @@
 config_file_version = 2
 services = nss, pam<% if node['sssd_ldap']['ldap_autofs'] %>, autofs<% end %><% if node['sssd_ldap']['ldap_ssh'] %>, ssh<% end %><% if node['sssd_ldap']['ldap_sudo'] && !(node['platform_family'] == 'rhel' && node['platform_version'].to_i < 6)%>, sudo<% end %>
 domains = LDAP
+<% node['sssd_ldap']['sssd_service_conf'].each do |key, value| %>
+<% if not value.nil? %><%= key %> = <%= value %><% end %>
+<% end %>
 
 [nss]
 filter_users = <%= node['sssd_ldap']['filter_users'].join(',') %>
-filter_groups = <%= node['sssd_ldap']['filter_groups'].join(',') %>
+filter_groups = <% if not node['sssd_ldap']['filter_groups'].empty? %><%= node['sssd_ldap']['filter_groups'].join(',') %><% end %>
 
 [pam]
 

--- a/templates/default/sssd.conf.erb
+++ b/templates/default/sssd.conf.erb
@@ -7,8 +7,11 @@ domains = LDAP
 <% end %>
 
 [nss]
-filter_users = <%= node['sssd_ldap']['filter_users'].join(',') %>
-filter_groups = <% if not node['sssd_ldap']['filter_groups'].nil? %><%= node['sssd_ldap']['filter_groups'].join(',') %><% end %>
+<% node['sssd_ldap']['nss_service_conf'].each do |key, value| %>
+<% if not value.nil? %><%= key %> = <%= value %><% end %>
+<% end %>
+filter_users = <%= node['sssd_ldap']['nss_conf']['filter_users'].join(',') %>
+filter_groups = <% if not node['sssd_ldap']['nss_conf']['filter_groups'].nil? %><%= node['sssd_ldap']['filter_groups'].join(',') %><% end %>
 
 [pam]
 

--- a/templates/default/sssd.conf.erb
+++ b/templates/default/sssd.conf.erb
@@ -4,15 +4,22 @@ services = nss, pam<% if node['sssd_ldap']['ldap_autofs'] %>, autofs<% end %><% 
 domains = LDAP
 
 [nss]
-<% node['sssd_ldap']['nss_service_conf'].each do |key, value| %>
-<% if not value.nil? %><%= key %> = <%= value %><% end %>
-<% end %>
-filter_users = <%= node['sssd_ldap']['nss_conf']['filter_users'].join(',') %>
-filter_groups = <% if not node['sssd_ldap']['nss_conf']['filter_groups'].nil? %><%= node['sssd_ldap']['filter_groups'].join(',') %><% end %>
-
-[pam]
+<%
+  node['sssd_ldap']['nss_service_conf'].each do |key, value|
+    if not value.nil?
+%>
+<%= key %> = <%= value %>
+<%
+    end
+  end
+%>
 
 [domain/LDAP]
-<% node['sssd_ldap']['sssd_conf'].each do |key, value| %>
-<% if not value.nil? %><%=  key %> = <%= value %><% end %>
-<% end %>
+<% node['sssd_ldap']['sssd_conf'].each do |key, value|
+    if not value.nil?
+%>
+<%= key %> = <%= value %>
+<%
+    end
+  end
+%>


### PR DESCRIPTION
- default['sssd_ldap']['nss_service_conf'] now works the same as default['sssd_ldap']['sssd_conf'] did. You can configure any key = value pairs for that section
- Fixed template so it doesn't inject empty lines if keys are nil