### PR TITLE
Remove nscd before authconfig is run

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,6 +18,12 @@
 # limitations under the License.
 #
 
+# NSCD and SSSD don't play well together.
+# https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/usingnscd-sssd.html
+package 'nscd' do
+  action :remove
+end
+
 package 'sssd' do
   action :install
 end
@@ -83,12 +89,6 @@ template '/etc/sssd/sssd.conf' do
   end
 
   notifies :restart, 'service[sssd]'
-end
-
-# NSCD and SSSD don't play well together.
-# https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/usingnscd-sssd.html
-package 'nscd' do
-  action :remove
 end
 
 service 'sssd' do


### PR DESCRIPTION
If nscd is installed when authconfig is run, it will prepend to /etc/sssd/sssd.conf
with something like:

	[domain/default]

	autofs_provider = ldap
	cache_credentials = True
	ldap_search_base = dc=acme,dc=com
	id_provider = ldap
	auth_provider = ldap
	chpass_provider = ldap
	ldap_uri = ldap://ldap1.acme.com,ldap://ldap2.acme.com
	ldap_id_use_start_tls = False
	ldap_tls_cacertdir = /etc/openldap/cacerts
	[sssd]
	domains = default,LDAP

Since this may not be a valid config, you cannot log into the system.
Removing nscd *before* authconfig is run fixes the issue.

Signed-off-by: joe.nuspl <nuspl@nvwls.com>

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ /] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [/] New functionality includes testing.
- [/] New functionality has been documented in the README if applicable
- [/] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
