### PR TITLE
Allow option to keep nscd installed where found

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Attribute                                  | Value                              
 `['ldap_sudo']`                            | `false`                                                                        | Adds ldap enabled sudoers (true/false)
 `['ldap_ssh']`                             | `false`                                                                        | Adds ldap enabled ssh keys (true/false)
 `['ldap_autofs']`                          | `false`                                                                        | Adds ldap enabled autofs config (true/false)
+`['uninstall_nscd']`                       | `true`                                                                         | Allows configuration to not uninstall nscd package if required
 
 ## Recipes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -57,3 +57,7 @@ default['sssd_ldap']['sssd_conf']['max_id'] = '0'
 default['sssd_ldap']['ldap_sudo'] = false
 default['sssd_ldap']['ldap_autofs'] = false
 default['sssd_ldap']['ldap_ssh'] = false
+
+# If you need nscd to stay installed set this to false.
+# See https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/usingnscd-sssd.html
+default['sssd_ldap']['uninstall_nscd'] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,6 +22,7 @@
 # https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/usingnscd-sssd.html
 package 'nscd' do
   action :remove
+  only_if { node['sssd_ldap']['uninstall_nscd'] }
 end
 
 package 'sssd' do


### PR DESCRIPTION
### Description

The current version of the sssd_ldap forces you to remove nscd.  This is understandable - a poorly configured (read: default) nscd configuration can cause poor sssd behaviour and results.  

However there are instances where having nscd for caching name resolution is required, whilst still using sssd to manage LDAP authentication and credential caching.  

This PR adds the option to disable the uninstall of nscd.  It does not change the default behaviour of doing this however.

### Issues Resolved

#36 

### Notes

- #35 makes notes from @nvwls about authconfig potentially pre-pending sssd.conf when run if nscd is installed.  We've not been able to replicate any issue but I would love some input here and felt that this should be highlighted before a merge!
- Having basically added a guard, then looked at spec/default_spec.rb, it doesn't look entirely complete and thus wasn't sure what to add where into the unit tests - if that can be clarified, happy to submit further changes.

### Check List

- [ X ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ? ] New functionality includes testing.
- [ X ] New functionality has been documented in the README if applicable
- [ X ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
