### PR TITLE
Give full path to authconfig.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache-2.0'
 description      'Sets up SSSD for LDAP on Ubuntu and RHEL systems'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '4.2.3'
+version          '4.2.4'
 
 %w(redhat centos amazon scientific oracle ubuntu debian).each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -68,7 +68,7 @@ if platform_family?('rhel', 'amazon')
 
   # Have authconfig enable SSSD in the pam files
   execute 'authconfig' do
-    command "authconfig #{node['sssd_ldap']['authconfig_params']}"
+    command "/usr/sbin/authconfig #{node['sssd_ldap']['authconfig_params']}"
     notifies :run, 'ruby_block[nsswitch sudoers]', :immediately
     action :nothing
   end


### PR DESCRIPTION
### Description

Puts the full path in for the command, this is just the obvious fix, perhaps there is something better.

### Issues Resolved

#38 

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [N/A] New functionality includes testing.
- [N/A ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
